### PR TITLE
Minimize chain structures hashing (part#1)

### DIFF
--- a/bencher/Cargo.toml
+++ b/bencher/Cargo.toml
@@ -10,7 +10,7 @@ storage = { path = "../storage" }
 db = { path = "../db" }
 verification = { path = "../verification" }
 network = { path = "../network" }
-chain = { path = "../chain" }
+chain = { path = "../chain", features = ["test-helpers"] }
 primitives = { path = "../primitives" }
 test-data = { path = "../test-data" }
 time = "*"

--- a/chain/Cargo.toml
+++ b/chain/Cargo.toml
@@ -11,3 +11,6 @@ primitives = { path = "../primitives" }
 serialization = { path = "../serialization" }
 serialization_derive = { path = "../serialization_derive" }
 
+[features]
+default = []
+test-helpers = []

--- a/chain/src/indexed_block.rs
+++ b/chain/src/indexed_block.rs
@@ -14,17 +14,12 @@ pub struct IndexedBlock {
 	pub transactions: Vec<IndexedTransaction>,
 }
 
+#[cfg(feature = "test-helpers")]
 impl From<Block> for IndexedBlock {
 	fn from(block: Block) -> Self {
-		let Block { block_header, transactions } = block;
-
-		IndexedBlock {
-			header: block_header.into(),
-			transactions: transactions.into_iter().map(Into::into).collect(),
-		}
+		Self::from_raw(block)
 	}
 }
-
 impl cmp::PartialEq for IndexedBlock {
 	fn eq(&self, other: &Self) -> bool {
 		self.header.hash == other.header.hash
@@ -37,6 +32,17 @@ impl IndexedBlock {
 			header: header,
 			transactions: transactions,
 		}
+	}
+
+	/// Explicit conversion of the raw Block into IndexedBlock.
+	///
+	/// Hashes block header + transactions.
+	pub fn from_raw(block: Block) -> Self {
+		let Block { block_header, transactions } = block;
+		Self::new(
+			IndexedBlockHeader::from_raw(block_header),
+			transactions.into_iter().map(IndexedTransaction::from_raw).collect(),
+		)
 	}
 
 	pub fn hash(&self) -> &H256 {

--- a/chain/src/indexed_header.rs
+++ b/chain/src/indexed_header.rs
@@ -19,21 +19,25 @@ impl fmt::Debug for IndexedBlockHeader {
 	}
 }
 
+#[cfg(feature = "test-helpers")]
 impl From<BlockHeader> for IndexedBlockHeader {
 	fn from(header: BlockHeader) -> Self {
-		IndexedBlockHeader {
-			hash: header.hash(),
-			raw: header,
-		}
+		Self::from_raw(header)
 	}
 }
-
 impl IndexedBlockHeader {
 	pub fn new(hash: H256, header: BlockHeader) -> Self {
 		IndexedBlockHeader {
 			hash: hash,
 			raw: header,
 		}
+	}
+
+	/// Explicit conversion of the raw BlockHeader into IndexedBlockHeader.
+	///
+	/// Hashes the contents of block header.
+	pub fn from_raw(header: BlockHeader) -> Self {
+		IndexedBlockHeader::new(header.hash(), header)
 	}
 }
 

--- a/chain/src/indexed_transaction.rs
+++ b/chain/src/indexed_transaction.rs
@@ -1,5 +1,6 @@
 use std::{cmp, io, fmt};
 use hash::H256;
+use heapsize::HeapSizeOf;
 use ser::{Deserializable, Reader, Error as ReaderError};
 use transaction::Transaction;
 use read_and_hash::ReadAndHash;
@@ -19,13 +20,16 @@ impl fmt::Debug for IndexedTransaction {
 	}
 }
 
+#[cfg(feature = "test-helpers")]
 impl<T> From<T> for IndexedTransaction where Transaction: From<T> {
 	fn from(other: T) -> Self {
-		let tx = Transaction::from(other);
-		IndexedTransaction {
-			hash: tx.hash(),
-			raw: tx,
-		}
+		Self::from_raw(other)
+	}
+}
+
+impl HeapSizeOf for IndexedTransaction {
+	fn heap_size_of_children(&self) -> usize {
+		self.raw.heap_size_of_children()
 	}
 }
 
@@ -35,6 +39,14 @@ impl IndexedTransaction {
 			hash: hash,
 			raw: transaction,
 		}
+	}
+
+	/// Explicit conversion of the raw Transaction into IndexedTransaction.
+	///
+	/// Hashes transaction contents.
+	pub fn from_raw<T>(transaction: T) -> Self where Transaction: From<T> {
+		let transaction = Transaction::from(transaction);
+		Self::new(transaction.hash(), transaction)
 	}
 }
 

--- a/miner/src/block_assembler.rs
+++ b/miner/src/block_assembler.rs
@@ -338,7 +338,7 @@ impl<'a> BlockAssembler<'a> {
 			bits: bits,
 			height: height,
 			transactions: transactions,
-			coinbase_tx: coinbase_tx.into(),
+			coinbase_tx: IndexedTransaction::from_raw(coinbase_tx),
 			size_limit: self.max_block_size,
 			sigop_limit: self.max_block_sigops,
 		})

--- a/miner/src/memory_pool.rs
+++ b/miner/src/memory_pool.rs
@@ -671,8 +671,9 @@ impl MemoryPool {
 
 	/// Removes single transaction by its hash.
 	/// All descendants remain in the pool.
-	pub fn remove_by_hash(&mut self, h: &H256) -> Option<Transaction> {
-		self.storage.remove_by_hash(h).map(|entry| entry.transaction)
+	pub fn remove_by_hash(&mut self, h: &H256) -> Option<IndexedTransaction> {
+		self.storage.remove_by_hash(h)
+			.map(|entry| IndexedTransaction::new(entry.hash, entry.transaction))
 	}
 
 	/// Checks if `transaction` spends some outputs, already spent by inpool transactions.
@@ -961,7 +962,7 @@ pub mod tests {
 		// remove and check remaining transactions
 		let removed = pool.remove_by_hash(&default_tx().hash());
 		assert!(removed.is_some());
-		assert_eq!(removed.unwrap(), default_tx());
+		assert_eq!(removed.unwrap(), default_tx().into());
 		assert_eq!(pool.get_transactions_ids().len(), 0);
 
 		// remove non-existant transaction

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -34,4 +34,9 @@ pub use net::Config as NetConfig;
 pub use p2p::{P2P, Context};
 pub use event_loop::{event_loop, forever};
 pub use util::{NodeTableError, PeerId, PeerInfo, InternetProtocol, Direction};
-pub use protocol::{InboundSyncConnection, InboundSyncConnectionRef, OutboundSyncConnection, OutboundSyncConnectionRef, LocalSyncNode, LocalSyncNodeRef};
+pub use protocol::{
+	InboundSyncConnection, InboundSyncConnectionRef,
+	InboundSyncConnectionState, InboundSyncConnectionStateRef,
+	OutboundSyncConnection, OutboundSyncConnectionRef,
+	LocalSyncNode, LocalSyncNodeRef,
+};

--- a/p2p/src/protocol/mod.rs
+++ b/p2p/src/protocol/mod.rs
@@ -8,7 +8,12 @@ use message::common::Command;
 
 pub use self::addr::{AddrProtocol, SeednodeProtocol};
 pub use self::ping::PingProtocol;
-pub use self::sync::{SyncProtocol, InboundSyncConnection, InboundSyncConnectionRef, OutboundSyncConnection, OutboundSyncConnectionRef, LocalSyncNode, LocalSyncNodeRef};
+pub use self::sync::{SyncProtocol,
+	InboundSyncConnection, InboundSyncConnectionRef,
+	InboundSyncConnectionState, InboundSyncConnectionStateRef,
+	OutboundSyncConnection, OutboundSyncConnectionRef,
+	LocalSyncNode, LocalSyncNodeRef,
+};
 
 pub trait Protocol: Send {
 	/// Initialize the protocol.

--- a/p2p/src/protocol/sync.rs
+++ b/p2p/src/protocol/sync.rs
@@ -7,12 +7,18 @@ use net::PeerContext;
 pub type InboundSyncConnectionRef = Box<InboundSyncConnection>;
 pub type OutboundSyncConnectionRef = Arc<OutboundSyncConnection>;
 pub type LocalSyncNodeRef = Box<LocalSyncNode>;
+pub type InboundSyncConnectionStateRef = Arc<InboundSyncConnectionState>;
 
 pub trait LocalSyncNode : Send + Sync {
 	fn create_sync_session(&self, height: i32, services: Services, outbound: OutboundSyncConnectionRef) -> InboundSyncConnectionRef;
 }
 
+pub trait InboundSyncConnectionState: Send + Sync {
+	fn synchronizing(&self) -> bool;
+}
+
 pub trait InboundSyncConnection : Send + Sync {
+	fn sync_state(&self) -> InboundSyncConnectionStateRef;
 	fn start_sync_session(&self, peer_name: String, version: types::Version);
 	fn close_session(&self);
 	fn on_inventory(&self, message: types::Inv);
@@ -143,15 +149,18 @@ impl OutboundSyncConnection for OutboundSync {
 pub struct SyncProtocol {
 	inbound_connection: InboundSyncConnectionRef,
 	context: Arc<PeerContext>,
+	state: InboundSyncConnectionStateRef,
 }
 
 impl SyncProtocol {
 	pub fn new(context: Arc<PeerContext>) -> Self {
 		let outbound_connection = Arc::new(OutboundSync::new(context.clone()));
 		let inbound_connection = context.global().create_sync_session(0, context.info().version_message.services(), outbound_connection);
+		let state = inbound_connection.sync_state();
 		SyncProtocol {
 			inbound_connection: inbound_connection,
 			context: context,
+			state: state,
 		}
 	}
 }
@@ -168,24 +177,49 @@ impl Protocol for SyncProtocol {
 	fn on_message(&mut self, command: &Command, payload: &Bytes) -> Result<(), Error> {
 		let version = self.context.info().version;
 		if command == &types::Inv::command() {
+			// we are synchronizing => we ask only for blocks with known headers => there are no useful blocks hashes for us
+			// we are synchronizing => we ignore all transactions until it is completed => there are no useful transactions hashes for us
+			if self.state.synchronizing() {
+				return Ok(());
+			}
+
 			let message: types::Inv = try!(deserialize_payload(payload, version));
 			self.inbound_connection.on_inventory(message);
 		}
 		else if command == &types::GetData::command() {
+			if self.state.synchronizing() {
+				return Ok(());
+			}
+
 			let message: types::GetData = try!(deserialize_payload(payload, version));
 			self.inbound_connection.on_getdata(message);
 		}
 		else if command == &types::GetBlocks::command() {
+			if self.state.synchronizing() {
+				return Ok(());
+			}
+
 			let message: types::GetBlocks = try!(deserialize_payload(payload, version));
 			self.inbound_connection.on_getblocks(message);
 		}
 		else if command == &types::GetHeaders::command() {
+			if self.state.synchronizing() {
+				return Ok(());
+			}
+
 			let message: types::GetHeaders = try!(deserialize_payload(payload, version));
 			let id = self.context.declare_response();
 			trace!("declared response {} for request: {}", id, types::GetHeaders::command());
 			self.inbound_connection.on_getheaders(message, id);
 		}
 		else if command == &types::Tx::command() {
+			// we ignore all transactions while synchronizing, as memory pool contains
+			// only verified transactions && we can not verify on-top transactions while
+			// we are not on the top
+			if self.state.synchronizing() {
+				return Ok(());
+			}
+
 			let message: types::Tx = try!(deserialize_payload(payload, version));
 			self.inbound_connection.on_transaction(message);
 		}
@@ -194,6 +228,10 @@ impl Protocol for SyncProtocol {
 			self.inbound_connection.on_block(message);
 		}
 		else if command == &types::MemPool::command() {
+			if self.state.synchronizing() {
+				return Ok(());
+			}
+
 			let message: types::MemPool = try!(deserialize_payload(payload, version));
 			self.inbound_connection.on_mempool(message);
 		}

--- a/pzec/util.rs
+++ b/pzec/util.rs
@@ -26,7 +26,7 @@ pub fn node_table_path(cfg: &Config) -> PathBuf {
 
 pub fn init_db(cfg: &Config) -> Result<(), String> {
 	// insert genesis block if db is empty
-	let genesis_block: IndexedBlock = cfg.network.genesis_block().into();
+	let genesis_block = IndexedBlock::from_raw(cfg.network.genesis_block());
 	match cfg.db.block_hash(0) {
 		Some(ref db_genesis_block_hash) if db_genesis_block_hash != genesis_block.hash() => Err("Trying to open database with incompatible genesis block".into()),
 		Some(_) => Ok(()),

--- a/rpc/src/v1/impls/blockchain.rs
+++ b/rpc/src/v1/impls/blockchain.rs
@@ -7,7 +7,7 @@ use keys::{self, Address};
 use v1::helpers::errors::{block_not_found, block_at_height_not_found, transaction_not_found,
 	transaction_output_not_found, transaction_of_side_branch, invalid_params};
 use jsonrpc_core::Error;
-use {storage, chain};
+use storage;
 use global_script::Script;
 use chain::OutPoint;
 use verification;
@@ -78,9 +78,8 @@ impl BlockChainClientCoreApi for BlockChainClientCore {
 	}
 
 	fn verbose_block(&self, hash: GlobalH256) -> Option<VerboseBlock> {
-		self.storage.block(hash.into())
+		self.storage.indexed_block(hash.into())
 			.map(|block| {
-				let block: chain::IndexedBlock = block.into();
 				let height = self.storage.block_number(block.hash());
 				let confirmations = match height {
 					Some(block_number) => (self.storage.best_block().number - block_number + 1) as i64,

--- a/rpc/src/v1/impls/raw.rs
+++ b/rpc/src/v1/impls/raw.rs
@@ -4,7 +4,10 @@ use v1::traits::Raw;
 use v1::types::{RawTransaction, TransactionInput, TransactionOutput, TransactionOutputs, Transaction, GetRawTransactionResponse};
 use v1::types::H256;
 use v1::helpers::errors::{execution, invalid_params};
-use chain::{SAPLING_TX_VERSION, SAPLING_TX_VERSION_GROUP_ID, Transaction as GlobalTransaction};
+use chain::{
+	SAPLING_TX_VERSION, SAPLING_TX_VERSION_GROUP_ID,
+	Transaction as GlobalTransaction, IndexedTransaction as GlobalIndexedTransaction,
+};
 use primitives::bytes::Bytes as GlobalBytes;
 use primitives::hash::H256 as GlobalH256;
 use sync;
@@ -118,7 +121,7 @@ impl RawClientCore {
 
 impl RawClientCoreApi for RawClientCore {
 	fn accept_transaction(&self, transaction: GlobalTransaction) -> Result<GlobalH256, String> {
-		self.local_sync_node.accept_transaction(transaction)
+		self.local_sync_node.accept_transaction(GlobalIndexedTransaction::from_raw(transaction))
 	}
 
 	fn create_raw_transaction(

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -31,3 +31,4 @@ network = { path = "../network" }
 [dev-dependencies]
 test-data = { path = "../test-data" }
 miner = { path = "../miner", features = ["test-helpers"] }
+chain = { path = "../chain", features = ["test-helpers"] }

--- a/sync/src/inbound_connection.rs
+++ b/sync/src/inbound_connection.rs
@@ -1,6 +1,6 @@
 use chain::{IndexedTransaction, IndexedBlock};
 use message::types;
-use p2p::{InboundSyncConnection, InboundSyncConnectionRef};
+use p2p::{InboundSyncConnection, InboundSyncConnectionRef, InboundSyncConnectionStateRef};
 use types::{PeersRef, LocalNodeRef, PeerIndex, RequestId};
 use utils::KnownHashType;
 
@@ -31,6 +31,10 @@ impl InboundConnection {
 }
 
 impl InboundSyncConnection for InboundConnection {
+	fn sync_state(&self) -> InboundSyncConnectionStateRef {
+		self.node.sync_state()
+	}
+
 	fn start_sync_session(&self, peer_name: String, version: types::Version) {
 		self.node.on_connect(self.peer_index, peer_name, version);
 	}

--- a/sync/src/inbound_connection.rs
+++ b/sync/src/inbound_connection.rs
@@ -77,13 +77,13 @@ impl InboundSyncConnection for InboundConnection {
 	}
 
 	fn on_transaction(&self, message: types::Tx) {
-		let tx: IndexedTransaction = message.transaction.into();
+		let tx = IndexedTransaction::from_raw(message.transaction);
 		self.peers.hash_known_as(self.peer_index, tx.hash.clone(), KnownHashType::Transaction);
 		self.node.on_transaction(self.peer_index, tx);
 	}
 
 	fn on_block(&self, message: types::Block) {
-		let block: IndexedBlock = message.block.into();
+		let block = IndexedBlock::from_raw(message.block);
 		self.peers.hash_known_as(self.peer_index, block.hash().clone(), KnownHashType::Block);
 		self.node.on_block(self.peer_index, block);
 	}

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -118,7 +118,7 @@ pub fn create_local_sync_node(consensus: ConsensusParams, db: storage::SharedSto
 	let verifier_sink = Arc::new(CoreVerificationSink::new(sync_client_core.clone()));
 	let verifier = AsyncVerifier::new(chain_verifier, db.clone(), memory_pool.clone(), verifier_sink, verification_params);
 	let sync_client = SynchronizationClient::new(sync_state.clone(), sync_client_core, verifier);
-	Arc::new(SyncNode::new(consensus, db, memory_pool, peers, sync_state, sync_executor, sync_client, sync_server))
+	Arc::new(SyncNode::new(consensus, db, memory_pool, peers, sync_state, sync_client, sync_server))
 }
 
 /// Create inbound synchronization connections factory for given local sync node.

--- a/sync/src/local_node.rs
+++ b/sync/src/local_node.rs
@@ -8,17 +8,16 @@ use message::types;
 use miner::BlockAssembler;
 use network::ConsensusParams;
 use synchronization_client::{Client};
-use synchronization_executor::{Task as SynchronizationTask, TaskExecutor};
 use synchronization_server::{Server, ServerTask};
 use synchronization_verifier::{TransactionVerificationSink};
 use primitives::hash::H256;
 use miner::BlockTemplate;
 use synchronization_peers::{TransactionAnnouncementType, BlockAnnouncementType};
-use types::{PeerIndex, RequestId, StorageRef, MemoryPoolRef, PeersRef, ExecutorRef,
+use types::{PeerIndex, RequestId, StorageRef, MemoryPoolRef, PeersRef,
 	ClientRef, ServerRef, SynchronizationStateRef, SyncListenerRef, BlockHeight};
 
 /// Local synchronization node
-pub struct LocalNode<T: TaskExecutor, U: Server, V: Client> {
+pub struct LocalNode<U: Server, V: Client> {
 	/// Network we are working on
 	consensus: ConsensusParams,
 	/// Storage reference
@@ -29,8 +28,6 @@ pub struct LocalNode<T: TaskExecutor, U: Server, V: Client> {
 	peers: PeersRef,
 	/// Shared synchronization state
 	state: SynchronizationStateRef,
-	/// Synchronization executor
-	executor: ExecutorRef<T>,
 	/// Synchronization process
 	client: ClientRef<V>,
 	/// Synchronization server
@@ -48,21 +45,25 @@ struct TransactionAcceptSinkData {
 	waiter: Condvar,
 }
 
-impl<T, U, V> LocalNode<T, U, V> where T: TaskExecutor, U: Server, V: Client {
+impl<U, V> LocalNode<U, V> where U: Server, V: Client {
 	/// Create new synchronization node
 	#[cfg_attr(feature="cargo-clippy", allow(too_many_arguments))]
 	pub fn new(consensus: ConsensusParams, storage: StorageRef, memory_pool: MemoryPoolRef, peers: PeersRef,
-		state: SynchronizationStateRef, executor: ExecutorRef<T>, client: ClientRef<V>, server: ServerRef<U>) -> Self {
+		state: SynchronizationStateRef, client: ClientRef<V>, server: ServerRef<U>) -> Self {
 		LocalNode {
 			consensus: consensus,
 			storage: storage,
 			memory_pool: memory_pool,
 			peers: peers,
 			state: state,
-			executor: executor,
 			client: client,
 			server: server,
 		}
+	}
+
+	/// Return shared reference to synchronization state.
+	pub fn sync_state(&self) -> SynchronizationStateRef {
+		self.state.clone()
 	}
 
 	/// When new peer connects to the node
@@ -100,14 +101,6 @@ impl<T, U, V> LocalNode<T, U, V> where T: TaskExecutor, U: Server, V: Client {
 
 	/// When transaction is received
 	pub fn on_transaction(&self, peer_index: PeerIndex, tx: IndexedTransaction) {
-		// we ignore all transactions while synchronizing, as memory pool contains
-		// only verified transactions && we can not verify on-top transactions while
-		// we are not on the top
-		if self.state.synchronizing() {
-			trace!(target: "sync", "Ignored `transaction` message from peer#{}. Tx hash: {}", peer_index, tx.hash.to_reversed_str());
-			return;
-		}
-
 		trace!(target: "sync", "Got `transaction` message from peer#{}. Tx hash: {}", peer_index, tx.hash.to_reversed_str());
 		self.client.on_transaction(peer_index, tx);
 	}
@@ -126,34 +119,18 @@ impl<T, U, V> LocalNode<T, U, V> where T: TaskExecutor, U: Server, V: Client {
 
 	/// When peer is requesting for items
 	pub fn on_getdata(&self, peer_index: PeerIndex, message: types::GetData) {
-		if self.state.synchronizing() {
-			trace!(target: "sync", "Ignored `getdata` message from peer#{}. Inventory len: {}", peer_index, message.inventory.len());
-			return;
-		}
-
 		trace!(target: "sync", "Got `getdata` message from peer#{}. Inventory len: {}", peer_index, message.inventory.len());
 		self.server.execute(ServerTask::GetData(peer_index, message));
 	}
 
 	/// When peer is requesting for known blocks hashes
 	pub fn on_getblocks(&self, peer_index: PeerIndex, message: types::GetBlocks) {
-		if self.state.synchronizing() {
-			trace!(target: "sync", "Ignored `getblocks` message from peer#{}", peer_index);
-			return;
-		}
-
 		trace!(target: "sync", "Got `getblocks` message from peer#{}", peer_index);
 		self.server.execute(ServerTask::GetBlocks(peer_index, message));
 	}
 
 	/// When peer is requesting for known blocks headers
 	pub fn on_getheaders(&self, peer_index: PeerIndex, message: types::GetHeaders, id: RequestId) {
-		if self.state.synchronizing() {
-			trace!(target: "sync", "Ignored `getheaders` message from peer#{}", peer_index);
-			self.executor.execute(SynchronizationTask::Ignore(peer_index, id));
-			return;
-		}
-
 		trace!(target: "sync", "Got `getheaders` message from peer#{}", peer_index);
 
 		// simulating bitcoind for passing tests: if we are in nearly-saturated state
@@ -170,11 +147,6 @@ impl<T, U, V> LocalNode<T, U, V> where T: TaskExecutor, U: Server, V: Client {
 
 	/// When peer is requesting for memory pool contents
 	pub fn on_mempool(&self, peer_index: PeerIndex, _message: types::MemPool) {
-		if self.state.synchronizing() {
-			trace!(target: "sync", "Ignored `mempool` message from peer#{}", peer_index);
-			return;
-		}
-
 		trace!(target: "sync", "Got `mempool` message from peer#{}", peer_index);
 		self.server.execute(ServerTask::Mempool(peer_index));
 	}
@@ -331,7 +303,7 @@ pub mod tests {
 		}
 	}
 
-	fn create_local_node(verifier: Option<DummyVerifier>) -> (Arc<DummyTaskExecutor>, Arc<DummyServer>, LocalNode<DummyTaskExecutor, DummyServer, SynchronizationClient<DummyTaskExecutor, DummyVerifier>>) {
+	fn create_local_node(verifier: Option<DummyVerifier>) -> (Arc<DummyTaskExecutor>, Arc<DummyServer>, LocalNode<DummyServer, SynchronizationClient<DummyTaskExecutor, DummyVerifier>>) {
 		let memory_pool = Arc::new(RwLock::new(MemoryPool::new()));
 		let storage = Arc::new(BlockChainDatabase::init_test_chain(vec![test_data::genesis().into()]));
 		let sync_state = SynchronizationStateRef::new(SynchronizationState::with_storage(storage.clone()));
@@ -348,7 +320,7 @@ pub mod tests {
 		};
 		verifier.set_sink(Arc::new(CoreVerificationSink::new(client_core.clone())));
 		let client = SynchronizationClient::new(sync_state.clone(), client_core, verifier);
-		let local_node = LocalNode::new(ConsensusParams::new(Network::Mainnet), storage, memory_pool, sync_peers, sync_state, executor.clone(), client, server.clone());
+		let local_node = LocalNode::new(ConsensusParams::new(Network::Mainnet), storage, memory_pool, sync_peers, sync_state, client, server.clone());
 		(executor, server, local_node)
 	}
 

--- a/sync/src/local_node.rs
+++ b/sync/src/local_node.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use parking_lot::{Mutex, Condvar};
 use time;
 use futures::{lazy, finished};
-use chain::{Transaction, IndexedTransaction, IndexedBlock};
+use chain::{IndexedTransaction, IndexedBlock};
 use keys::Address;
 use message::types;
 use miner::BlockAssembler;
@@ -217,7 +217,7 @@ impl<T, U, V> LocalNode<T, U, V> where T: TaskExecutor, U: Server, V: Client {
 	}
 
 	/// Verify and then schedule new transaction
-	pub fn accept_transaction(&self, transaction: Transaction) -> Result<H256, String> {
+	pub fn accept_transaction(&self, transaction: IndexedTransaction) -> Result<H256, String> {
 		let sink_data = Arc::new(TransactionAcceptSinkData::default());
 		let sink = TransactionAcceptSink::new(sink_data.clone()).boxed();
 		{
@@ -384,7 +384,7 @@ pub mod tests {
 		let transaction: Transaction = test_data::TransactionBuilder::with_output(1).add_input(&genesis.transactions[0], 0).into();
 		let transaction_hash = transaction.hash();
 
-		let result = local_node.accept_transaction(transaction.clone());
+		let result = local_node.accept_transaction(transaction.clone().into());
 		assert_eq!(result, Ok(transaction_hash.clone()));
 
 		assert_eq!(executor.take_tasks(), vec![Task::RelayNewTransaction(transaction.into(), 0)]);
@@ -405,7 +405,7 @@ pub mod tests {
 		let peer_index1 = 0; local_node.on_connect(peer_index1, "test".into(), types::Version::default());
 		executor.take_tasks();
 
-		let result = local_node.accept_transaction(transaction);
+		let result = local_node.accept_transaction(transaction.into());
 		assert_eq!(result, Err("simulated".to_owned()));
 
 		assert_eq!(executor.take_tasks(), vec![]);

--- a/sync/src/synchronization_chain.rs
+++ b/sync/src/synchronization_chain.rs
@@ -246,7 +246,7 @@ impl Chain {
 	/// Get block header by number
 	pub fn block_header_by_number(&self, number: BlockHeight) -> Option<IndexedBlockHeader> {
 		if number <= self.best_storage_block.number {
-			self.storage.block_header(storage::BlockRef::Number(number)).map(Into::into)
+			self.storage.indexed_block_header(storage::BlockRef::Number(number))
 		} else {
 			self.headers_chain.at(number - self.best_storage_block.number)
 		}
@@ -254,8 +254,8 @@ impl Chain {
 
 	/// Get block header by hash
 	pub fn block_header_by_hash(&self, hash: &H256) -> Option<IndexedBlockHeader> {
-		if let Some(block) = self.storage.block(storage::BlockRef::Hash(hash.clone())) {
-			return Some(block.block_header.into());
+		if let Some(header) = self.storage.indexed_block_header(storage::BlockRef::Hash(hash.clone())) {
+			return Some(header);
 		}
 		self.headers_chain.by_hash(hash)
 	}
@@ -591,7 +591,9 @@ impl Chain {
 	/// Get transaction by hash (if it's in memory pool or verifying)
 	pub fn transaction_by_hash(&self, hash: &H256) -> Option<IndexedTransaction> {
 		self.verifying_transactions.get(hash).cloned()
-			.or_else(|| self.memory_pool.read().read_by_hash(hash).cloned().map(|t| t.into()))
+			.or_else(|| self.memory_pool.read().read_by_hash(hash)
+				.cloned()
+				.map(|tx| IndexedTransaction::new(hash.clone(), tx)))
 	}
 
 	/// Insert transaction to memory pool

--- a/sync/src/synchronization_client.rs
+++ b/sync/src/synchronization_client.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use parking_lot::Mutex;
-use chain::{IndexedTransaction, Transaction, IndexedBlock};
+use chain::{IndexedTransaction, IndexedBlock};
 use message::types;
 use synchronization_executor::TaskExecutor;
 use synchronization_verifier::{Verifier, TransactionVerificationSink};
@@ -129,7 +129,7 @@ pub trait Client : Send + Sync + 'static {
 	fn on_transaction(&self, peer_index: PeerIndex, transaction: IndexedTransaction);
 	fn on_notfound(&self, peer_index: PeerIndex, message: types::NotFound);
 	fn after_peer_nearly_blocks_verified(&self, peer_index: PeerIndex, future: EmptyBoxFuture);
-	fn accept_transaction(&self, transaction: Transaction, sink: Box<TransactionVerificationSink>) -> Result<(), String>;
+	fn accept_transaction(&self, transaction: IndexedTransaction, sink: Box<TransactionVerificationSink>) -> Result<(), String>;
 	fn install_sync_listener(&self, listener: SyncListenerRef);
 }
 
@@ -214,7 +214,7 @@ impl<T, U> Client for SynchronizationClient<T, U> where T: TaskExecutor, U: Veri
 		self.core.lock().after_peer_nearly_blocks_verified(peer_index, future);
 	}
 
-	fn accept_transaction(&self, transaction: Transaction, sink: Box<TransactionVerificationSink>) -> Result<(), String> {
+	fn accept_transaction(&self, transaction: IndexedTransaction, sink: Box<TransactionVerificationSink>) -> Result<(), String> {
 		let mut transactions_to_verify = try!(self.core.lock().accept_transaction(transaction, sink));
 
 		let next_block_height = self.shared_state.best_storage_block_height() + 1;

--- a/sync/src/synchronization_client_core.rs
+++ b/sync/src/synchronization_client_core.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use futures::Future;
 use parking_lot::Mutex;
 use time::precise_time_s;
-use chain::{IndexedBlockHeader, IndexedTransaction, Transaction, IndexedBlock};
+use chain::{IndexedBlockHeader, IndexedTransaction, IndexedBlock};
 use message::types;
 use message::common::{InventoryType, InventoryVector};
 use miner::transaction_fee_rate;
@@ -72,7 +72,7 @@ pub trait ClientCore {
 	fn on_transaction(&mut self, peer_index: PeerIndex, transaction: IndexedTransaction) -> Option<VecDeque<IndexedTransaction>>;
 	fn on_notfound(&mut self, peer_index: PeerIndex, message: types::NotFound);
 	fn after_peer_nearly_blocks_verified(&mut self, peer_index: PeerIndex, future: EmptyBoxFuture);
-	fn accept_transaction(&mut self, transaction: Transaction, sink: Box<TransactionVerificationSink>) -> Result<VecDeque<IndexedTransaction>, String>;
+	fn accept_transaction(&mut self, transaction: IndexedTransaction, sink: Box<TransactionVerificationSink>) -> Result<VecDeque<IndexedTransaction>, String>;
 	fn install_sync_listener(&mut self, listener: SyncListenerRef);
 	fn execute_synchronization_tasks(&mut self, forced_blocks_requests: Option<Vec<H256>>, final_blocks_requests: Option<Vec<H256>>);
 	fn try_switch_to_saturated_state(&mut self) -> bool;
@@ -270,7 +270,7 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 		assert!(!message.headers.is_empty(), "This must be checked in incoming connection");
 
 		// transform to indexed headers
-		let mut headers: Vec<_> = message.headers.into_iter().map(IndexedBlockHeader::from).collect();
+		let mut headers: Vec<_> = message.headers.into_iter().map(IndexedBlockHeader::from_raw).collect();
 
 		// update peers to select next tasks
 		self.peers_tasks.on_headers_received(peer_index);
@@ -514,9 +514,9 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 		}
 	}
 
-	fn accept_transaction(&mut self, transaction: Transaction, sink: Box<TransactionVerificationSink>) -> Result<VecDeque<IndexedTransaction>, String> {
-		let hash = transaction.hash();
-		match self.try_append_transaction(transaction.into(), true) {
+	fn accept_transaction(&mut self, transaction: IndexedTransaction, sink: Box<TransactionVerificationSink>) -> Result<VecDeque<IndexedTransaction>, String> {
+		let hash = transaction.hash;
+		match self.try_append_transaction(transaction, true) {
 			Err(AppendTransactionError::Orphan(_)) => Err("Cannot append transaction as its inputs are unknown".to_owned()),
 			Err(AppendTransactionError::Synchronizing) => Err("Cannot append transaction as node is not yet fully synchronized".to_owned()),
 			Ok(transactions) => {
@@ -1086,8 +1086,8 @@ impl<T> SynchronizationClientCore<T> where T: TaskExecutor {
 				// relay block to our peers
 				if needs_relay && (self.state.is_saturated() || self.state.is_nearly_saturated()) {
 					for block_hash in insert_result.canonized_blocks_hashes {
-						if let Some(block) = self.chain.storage().block(block_hash.into()) {
-							self.executor.execute(Task::RelayNewBlock(block.into()));
+						if let Some(block) = self.chain.storage().indexed_block(block_hash.into()) {
+							self.executor.execute(Task::RelayNewBlock(block));
 						}
 					}
 				}

--- a/sync/src/synchronization_client_core.rs
+++ b/sync/src/synchronization_client_core.rs
@@ -218,13 +218,6 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 	}
 
 	fn on_inventory(&self, peer_index: PeerIndex, message: types::Inv) {
-		// we are synchronizing => we ask only for blocks with known headers => there are no useful blocks hashes for us
-		// we are synchronizing => we ignore all transactions until it is completed => there are no useful transactions hashes for us
-		if self.state.is_synchronizing() {
-			trace!(target: "sync", "Ignoring {} inventory items from peer#{} as synchronization is in progress", message.inventory.len(), peer_index);
-			return;
-		}
-
 		// else ask for all unknown transactions and blocks
 		let unknown_inventory: Vec<_> = message.inventory.into_iter()
 			.filter(|item| {
@@ -1831,23 +1824,6 @@ pub mod tests {
 		assert_eq!(core.lock().information().peers_tasks.idle, 0);
 		assert_eq!(core.lock().information().peers_tasks.unuseful, 0);
 		assert_eq!(core.lock().information().peers_tasks.active, 1);
-	}
-
-	#[test]
-	fn transaction_is_not_requested_when_synchronizing() {
-		let (executor, core, sync) = create_sync(None, None);
-
-		let b1 = test_data::block_h1();
-		let b2 = test_data::block_h2();
-		sync.on_headers(1, types::Headers::with_headers(vec![b1.block_header.clone(), b2.block_header.clone()]));
-
-		assert!(core.lock().information().state.is_synchronizing());
-		{ executor.take_tasks(); } // forget tasks
-
-		sync.on_inventory(0, types::Inv::with_inventory(vec![InventoryVector::tx(H256::from(0))]));
-
-		let tasks = executor.take_tasks();
-		assert_eq!(tasks, vec![]);
 	}
 
 	#[test]

--- a/sync/src/synchronization_server.rs
+++ b/sync/src/synchronization_server.rs
@@ -269,16 +269,16 @@ impl<TExecutor> ServerTaskExecutor<TExecutor> where TExecutor: TaskExecutor {
 				}
 			},
 			common::InventoryType::MessageBlock => {
-				if let Some(block) = self.storage.block(next_item.hash.clone().into()) {
+				if let Some(block) = self.storage.indexed_block(next_item.hash.clone().into()) {
 					trace!(target: "sync", "'getblocks' response to peer#{} is ready with block {}", peer_index, next_item.hash.to_reversed_str());
-					self.executor.execute(Task::Block(peer_index, block.into()));
+					self.executor.execute(Task::Block(peer_index, block));
 				} else {
 					notfound.inventory.push(next_item);
 				}
 			},
 			common::InventoryType::MessageFilteredBlock => {
-				if let Some(block) = self.storage.block(next_item.hash.clone().into()) {
-					let message_artefacts = self.peers.build_merkle_block(peer_index, &block.into());
+				if let Some(block) = self.storage.indexed_block(next_item.hash.clone().into()) {
+					let message_artefacts = self.peers.build_merkle_block(peer_index, &block);
 					if let Some(message_artefacts) = message_artefacts {
 						// send merkleblock first
 						trace!(target: "sync", "'getblocks' response to peer#{} is ready with merkleblock {}", peer_index, next_item.hash.to_reversed_str());

--- a/sync/src/synchronization_verifier.rs
+++ b/sync/src/synchronization_verifier.rs
@@ -170,7 +170,7 @@ impl AsyncVerifier {
 						},
 						Ok(tx_output_provider) => {
 							let time: u32 = get_time().sec as u32;
-							match verifier.verifier.verify_mempool_transaction(storage.as_block_header_provider(), &tx_output_provider, height, time, &transaction.raw) {
+							match verifier.verifier.verify_mempool_transaction(storage.as_block_header_provider(), &tx_output_provider, height, time, &transaction) {
 								Ok(_) => sink.on_transaction_verification_success(transaction.into()),
 								Err(e) => sink.on_transaction_verification_error(&format!("{:?}", e), &transaction.hash),
 							}

--- a/sync/src/types.rs
+++ b/sync/src/types.rs
@@ -48,7 +48,7 @@ pub type ClientCoreRef<T> = Arc<Mutex<T>>;
 pub type ServerRef<T> = Arc<T>;
 
 /// Reference to local node
-pub type LocalNodeRef = Arc<LocalNode<LocalSynchronizationTaskExecutor, ServerImpl, SynchronizationClient<LocalSynchronizationTaskExecutor, AsyncVerifier>>>;
+pub type LocalNodeRef = Arc<LocalNode<ServerImpl, SynchronizationClient<LocalSynchronizationTaskExecutor, AsyncVerifier>>>;
 
 /// Synchronization events listener reference
 pub type SyncListenerRef = Box<SyncListener>;

--- a/sync/src/utils/synchronization_state.rs
+++ b/sync/src/utils/synchronization_state.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use p2p::InboundSyncConnectionState;
 use super::super::types::{StorageRef, BlockHeight};
 
 // AtomicU32 is unstable => using AtomicUsize here
@@ -36,5 +37,11 @@ impl SynchronizationState {
 
 	pub fn update_best_storage_block_height(&self, height: BlockHeight) {
 		self.best_storage_block_height.store(height as usize, Ordering::SeqCst);
+	}
+}
+
+impl InboundSyncConnectionState for SynchronizationState {
+	fn synchronizing(&self) -> bool {
+		SynchronizationState::synchronizing(self)
 	}
 }

--- a/verification/Cargo.toml
+++ b/verification/Cargo.toml
@@ -24,3 +24,4 @@ rand = "0.4"
 test-data = { path = "../test-data" }
 db = { path = "../db" }
 assert_matches = "1.3.0"
+chain = { path = "../chain", features = ["test-helpers"] }

--- a/verification/src/chain_verifier.rs
+++ b/verification/src/chain_verifier.rs
@@ -1,7 +1,7 @@
 //! Bitcoin chain verifier
 
 use hash::H256;
-use chain::{IndexedBlock, IndexedBlockHeader, BlockHeader, Transaction};
+use chain::{IndexedBlock, IndexedBlockHeader, BlockHeader, IndexedTransaction};
 use storage::{SharedStore, TransactionOutputProvider, BlockHeaderProvider, BlockOrigin,
 	DuplexTransactionOutputProvider, NoopStore};
 use network::ConsensusParams;
@@ -103,15 +103,14 @@ impl BackwardsCompatibleChainVerifier {
 		prevout_provider: &T,
 		height: u32,
 		time: u32,
-		transaction: &Transaction,
+		transaction: &IndexedTransaction,
 	) -> Result<(), TransactionError> where T: TransactionOutputProvider {
-		let indexed_tx = transaction.clone().into();
 		// let's do preverification first
 		let deployments = BlockDeployments::new(&self.deployments, height, block_header_provider, &self.consensus);
-		let tx_verifier = MemoryPoolTransactionVerifier::new(&indexed_tx, &self.consensus);
+		let tx_verifier = MemoryPoolTransactionVerifier::new(&transaction, &self.consensus);
 		try!(tx_verifier.check());
 
-		let canon_tx = CanonTransaction::new(&indexed_tx);
+		let canon_tx = CanonTransaction::new(&transaction);
 		// now let's do full verification
 		let noop = NoopStore;
 		let output_store = DuplexTransactionOutputProvider::new(prevout_provider, &noop);


### PR DESCRIPTION
- removed implicit `From` of non-indexed structures (`BlockHeader`, `Transaction`, `Block`) into indexed (`IndexedBlockHeader`, `IndexedTransaction`, `IndexedBlock`). This eases search for all those (quite) heavy operations + ensures that all (in future) `chain-structure.hash()` calls will be localized inside these (`from_raw`) methods;
- moved code that has ignored messages, when synchronization is active, from `sync` to `p2p` module. So now we can ignore messages before they are decoded (and sometimes hashed). This has been wasting a lot of CPU time during sync, because we are ignoring `tx` messages && the code that ignored those messages  was accepting `IndexedTransaction` structure (so => decode + hash + ignore && now it is simply ignore).

Should be backported to `pbtc`