### PR TITLE
Mark allow(dead_code) on compute_hsig() for now

### DIFF
--- a/verification/src/sprout.rs
+++ b/verification/src/sprout.rs
@@ -1,4 +1,4 @@
-
+#[allow(dead_code)]
 // blake2 hash of (random_seed, nullifier[0], nullifier[1], pub_key_hash) with 'ZcashComputehSig' personal token
 pub fn compute_hsig(random_seed: [u8; 32], nullifiers: [[u8; 32]; 2], pub_key_hash: [u8; 32]) -> [u8; 32] {
 	use crypto::blake2::Params;


### PR DESCRIPTION
Quiets the only warning from `cargo test`. 