### PR TITLE
Actually verify headers

### DIFF
--- a/sync/src/synchronization_client.rs
+++ b/sync/src/synchronization_client.rs
@@ -187,9 +187,11 @@ impl<T, U> Client for SynchronizationClient<T, U> where T: TaskExecutor, U: Veri
 
 		// in case if verification was synchronous
 		// => try to switch to saturated state OR execute sync tasks
-		let mut client = self.core.lock();
-		if !client.try_switch_to_saturated_state() {
-			client.execute_synchronization_tasks(None, None);
+		if self.light_verifier.is_idle() {
+			let mut client = self.core.lock();
+			if !client.try_switch_to_saturated_state() {
+				client.execute_synchronization_tasks(None, None);
+			}
 		}
 	}
 

--- a/sync/src/synchronization_client_core.rs
+++ b/sync/src/synchronization_client_core.rs
@@ -1028,11 +1028,9 @@ impl<T> SynchronizationClientCore<T> where T: TaskExecutor {
 
 	fn on_headers_verification_success(&mut self, headers: Vec<IndexedBlockHeader>) {
 		let headers = self.find_unknown_headers(headers);
-		if headers.is_empty() {
-			return;
+		if !headers.is_empty() {
+			self.chain.schedule_blocks_headers(headers);
 		}
-
-		self.chain.schedule_blocks_headers(headers);
 
 		// switch to synchronization state
 		if !self.state.is_synchronizing() {

--- a/sync/src/synchronization_verifier.rs
+++ b/sync/src/synchronization_verifier.rs
@@ -81,8 +81,6 @@ pub struct ChainVerifierWrapper {
 	verification_params: VerificationParameters,
 	/// True if we have passed verification edge && full verification is required.
 	pub enforce_full_verification: AtomicBool,
-	/// True if we need to actually verify headers.
-	verify_headers: bool,
 }
 
 impl ChainVerifierWrapper {
@@ -93,16 +91,12 @@ impl ChainVerifierWrapper {
 			verifier: verifier,
 			verification_params: verification_params,
 			enforce_full_verification: enforce_full_verification,
-			verify_headers: false,
 		}
 	}
 
 	/// Verify header.
 	pub fn verify_block_header(&self, header: &IndexedBlockHeader) -> Result<(), VerificationError> {
-		match self.verify_headers {
-			true => self.verifier.verify_block_header(header),
-			false => Ok(()),
-		}
+		self.verifier.verify_block_header(header)
 	}
 
 	/// Verify block.


### PR DESCRIPTION
broke this earlier today in #67 

+ also do not switch to saturated state when headers are verifying. It isn't critical, but annoying - it spoils the console.