### PR TITLE
Disable TransactionDoubleSpend for coinbase transactions

### DIFF
--- a/verification/src/accept_transaction.rs
+++ b/verification/src/accept_transaction.rs
@@ -453,6 +453,10 @@ impl<'a> TransactionDoubleSpend<'a> {
 	}
 
 	fn check(&self) -> Result<(), TransactionError> {
+		if self.transaction.raw.is_coinbase() {
+			return Ok(());
+		}
+
 		for input in &self.transaction.raw.inputs {
 			if self.store.is_spent(&input.previous_output) {
 				return Err(TransactionError::UsingSpentOutput(


### PR DESCRIPTION
Verification thread spends a lot of time (especially at first blocks) deserializing data from disk db. This PR decreases a number of `deserialize()` calls, though we probably could think about caching deserialized structures at db level.