### PR TITLE
Cache transaction outputs in ChainAcceptor

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -42,7 +42,9 @@ pub use duplex_store::{DuplexTransactionOutputProvider, NoopStore};
 pub use error::Error;
 pub use store::{AsSubstore, Store, SharedStore, CanonStore};
 pub use transaction_meta::TransactionMeta;
-pub use transaction_provider::{TransactionProvider, TransactionOutputProvider, TransactionMetaProvider};
+pub use transaction_provider::{
+	TransactionProvider, TransactionOutputProvider, TransactionMetaProvider, CachedTransactionOutputProvider,
+};
 pub use nullifier_tracker::NullifierTracker;
 pub use tree_state::{TreeState, H32 as H32TreeDim, Dim as TreeDim, SproutTreeState, SaplingTreeState};
 pub use tree_state_provider::TreeStateProvider;

--- a/storage/src/transaction_provider.rs
+++ b/storage/src/transaction_provider.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+use parking_lot::RwLock;
 use hash::H256;
 use bytes::Bytes;
 use chain::{IndexedTransaction, OutPoint, TransactionOutput};
@@ -31,4 +33,41 @@ pub trait TransactionMetaProvider: Send + Sync {
 	/// Returns None if transaction with given hash does not exist
 	/// Otherwise returns transaction meta object
 	fn transaction_meta(&self, hash: &H256) -> Option<TransactionMeta>;
+}
+
+/// Transaction output provider that caches all read outputs.
+///
+/// Not intended for long-lasting life, because it never clears its internal
+/// cache. The backing storage is considered readonly for the cache lifetime.
+pub struct CachedTransactionOutputProvider<'a> {
+	backend: &'a TransactionOutputProvider,
+	cached_outputs: RwLock<HashMap<OutPoint, Option<TransactionOutput>>>,
+}
+
+impl<'a> CachedTransactionOutputProvider<'a> {
+	/// Create new cached tx output provider backed by passed provider.
+	pub fn new(backend: &'a TransactionOutputProvider) -> Self {
+		CachedTransactionOutputProvider {
+			backend,
+			cached_outputs: RwLock::new(HashMap::new()),
+		}
+	}
+}
+
+impl<'a> TransactionOutputProvider for CachedTransactionOutputProvider<'a> {
+	fn transaction_output(&self, outpoint: &OutPoint, transaction_index: usize) -> Option<TransactionOutput> {
+		let cached_value = self.cached_outputs.read().get(outpoint).cloned();
+		match cached_value {
+			Some(cached_value) => cached_value,
+			None => {
+				let value_from_backend = self.backend.transaction_output(outpoint, transaction_index);
+				self.cached_outputs.write().insert(outpoint.clone(), value_from_backend.clone());
+				value_from_backend
+			},
+		}
+	}
+
+	fn is_spent(&self, outpoint: &OutPoint) -> bool {
+		self.backend.is_spent(outpoint)
+	}
 }


### PR DESCRIPTION
This PR finally makes (heavy) sync verification thread performance bound by `secp256k1_*` functions (i.e. tx signature checks) => most of `pzec` overhead has gone.

Instead of making global (db-level) cache, I've limited its lifetime by single block check - this makes cache maintenance easier + I'm not sure that global cache will increase performance at all (because distance between tx-out-introducing-block and tx-spend-block could be huge).We were reading + deserializing the same tx-outs 6 times for every block' transaction input: (1) in `BlockCoinbaseMinerReward` (2) in `TransactionMissingInputs` (3) in `TransactionOverspent` (4) in `TransactionEval` (5) in `TransactionSigops` and (6) in `BlockSigops`. Now we read every txout only once && use the cached version afterwards