### PR TITLE
Hash header(s) without holding sync lock

### DIFF
--- a/sync/src/inbound_connection.rs
+++ b/sync/src/inbound_connection.rs
@@ -1,4 +1,4 @@
-use chain::{IndexedTransaction, IndexedBlock};
+use chain::{IndexedTransaction, IndexedBlock, IndexedBlockHeader};
 use message::types;
 use p2p::{InboundSyncConnection, InboundSyncConnectionRef, InboundSyncConnectionStateRef};
 use types::{PeersRef, LocalNodeRef, PeerIndex, RequestId};
@@ -103,7 +103,8 @@ impl InboundSyncConnection for InboundConnection {
 			return;
 		}
 
-		self.node.on_headers(self.peer_index, message);
+		let headers = message.headers.into_iter().map(IndexedBlockHeader::from_raw).collect();
+		self.node.on_headers(self.peer_index, headers);
 	}
 
 	fn on_mempool(&self, message: types::MemPool) {

--- a/sync/src/local_node.rs
+++ b/sync/src/local_node.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use parking_lot::{Mutex, Condvar};
 use time;
 use futures::{lazy, finished};
-use chain::{IndexedTransaction, IndexedBlock};
+use chain::{IndexedTransaction, IndexedBlock, IndexedBlockHeader};
 use keys::Address;
 use message::types;
 use miner::BlockAssembler;
@@ -94,9 +94,9 @@ impl<U, V> LocalNode<U, V> where U: Server, V: Client {
 	}
 
 	/// When headers message is received
-	pub fn on_headers(&self, peer_index: PeerIndex, message: types::Headers) {
-		trace!(target: "sync", "Got `headers` message from peer#{}. Headers len: {}", peer_index, message.headers.len());
-		self.client.on_headers(peer_index, message);
+	pub fn on_headers(&self, peer_index: PeerIndex, headers: Vec<IndexedBlockHeader>) {
+		trace!(target: "sync", "Got `headers` message from peer#{}. Headers len: {}", peer_index, headers.len());
+		self.client.on_headers(peer_index, headers);
 	}
 
 	/// When transaction is received

--- a/sync/src/synchronization_client.rs
+++ b/sync/src/synchronization_client.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use parking_lot::Mutex;
-use chain::{IndexedTransaction, IndexedBlock};
+use chain::{IndexedTransaction, IndexedBlock, IndexedBlockHeader};
 use message::types;
 use synchronization_executor::TaskExecutor;
 use synchronization_verifier::{Verifier, TransactionVerificationSink};
@@ -124,7 +124,7 @@ pub trait Client : Send + Sync + 'static {
 	fn on_connect(&self, peer_index: PeerIndex);
 	fn on_disconnect(&self, peer_index: PeerIndex);
 	fn on_inventory(&self, peer_index: PeerIndex, message: types::Inv);
-	fn on_headers(&self, peer_index: PeerIndex, message: types::Headers);
+	fn on_headers(&self, peer_index: PeerIndex, headers: Vec<IndexedBlockHeader>);
 	fn on_block(&self, peer_index: PeerIndex, block: IndexedBlock);
 	fn on_transaction(&self, peer_index: PeerIndex, transaction: IndexedTransaction);
 	fn on_notfound(&self, peer_index: PeerIndex, message: types::NotFound);
@@ -160,8 +160,8 @@ impl<T, U> Client for SynchronizationClient<T, U> where T: TaskExecutor, U: Veri
 		self.core.lock().on_inventory(peer_index, message);
 	}
 
-	fn on_headers(&self, peer_index: PeerIndex, message: types::Headers) {
-		let headers_to_verify = self.core.lock().on_headers(peer_index, message);
+	fn on_headers(&self, peer_index: PeerIndex, headers: Vec<IndexedBlockHeader>) {
+		let headers_to_verify = self.core.lock().on_headers(peer_index, headers);
 		if let Some(headers_to_verify) = headers_to_verify {
 			self.light_verifier.verify_headers(peer_index, headers_to_verify);
 		}

--- a/sync/src/synchronization_client_core.rs
+++ b/sync/src/synchronization_client_core.rs
@@ -1424,7 +1424,7 @@ pub mod tests {
 		let block1: Block = test_data::block_h1();
 		let block2: Block = test_data::block_h2();
 
-		sync.on_headers(5, types::Headers::with_headers(vec![block1.block_header.clone()]));
+		sync.on_headers(5, vec![block1.block_header.clone().into()]);
 		let tasks = executor.take_tasks();
 		assert_eq!(tasks, vec![request_block_headers_genesis_and(5, vec![block1.hash()]), request_blocks(5, vec![block1.hash()])]);
 		assert!(core.lock().information().state.is_nearly_saturated());
@@ -1461,7 +1461,10 @@ pub mod tests {
 	fn synchronization_out_of_order_block_path() {
 		let (_, core, sync) = create_sync(None, None);
 
-		sync.on_headers(5, types::Headers::with_headers(vec![test_data::block_h1().block_header.clone(), test_data::block_h2().block_header.clone()]));
+		sync.on_headers(5, vec![
+			test_data::block_h1().block_header.into(),
+			test_data::block_h2().block_header.into(),
+		]);
 		sync.on_block(5, test_data::block_h169().into());
 
 		// out-of-order block was presented by the peer
@@ -1487,7 +1490,7 @@ pub mod tests {
 			// not synchronizing after start
 			assert!(core.lock().information().state.is_saturated());
 			// receive inventory from new peer#1
-			sync.on_headers(1, types::Headers::with_headers(vec![block1.block_header.clone()]));
+			sync.on_headers(1, vec![block1.block_header.clone().into()]);
 			assert_eq!(core.lock().information().chain.requested, 1);
 			// synchronization has started && new blocks have been requested
 			let tasks = executor.take_tasks();
@@ -1497,7 +1500,7 @@ pub mod tests {
 
 		{
 			// receive inventory from new peer#2
-			sync.on_headers(2, types::Headers::with_headers(vec![block1.block_header.clone(), block2.block_header.clone()]));
+			sync.on_headers(2, vec![block1.block_header.clone().into(), block2.block_header.clone().into()]);
 			assert_eq!(core.lock().information().chain.requested, 2);
 			// synchronization has started && new blocks have been requested
 			let tasks = executor.take_tasks();
@@ -1526,7 +1529,7 @@ pub mod tests {
 
 		// request new blocks
 		{
-			sync.on_headers(1, types::Headers::with_headers(vec![test_data::block_h1().block_header]));
+			sync.on_headers(1, vec![test_data::block_h1().block_header.into()]);
 			assert!(core.lock().information().state.is_nearly_saturated());
 		}
 
@@ -1541,7 +1544,7 @@ pub mod tests {
 	fn synchronization_not_starting_when_receiving_known_blocks() {
 		let (executor, core, sync) = create_sync(None, None);
 		// saturated => receive inventory with known blocks only
-		sync.on_headers(1, types::Headers::with_headers(vec![test_data::genesis().block_header]));
+		sync.on_headers(1, vec![test_data::genesis().block_header.into()]);
 		// => no need to start synchronization
 		assert!(!core.lock().information().state.is_nearly_saturated());
 		// => no synchronization tasks are scheduled
@@ -1553,8 +1556,8 @@ pub mod tests {
 	fn synchronization_asks_for_inventory_after_saturating() {
 		let (executor, _, sync) = create_sync(None, None);
 		let block = test_data::block_h1();
-		sync.on_headers(1, types::Headers::with_headers(vec![block.block_header.clone()]));
-		sync.on_headers(2, types::Headers::with_headers(vec![block.block_header.clone()]));
+		sync.on_headers(1, vec![block.block_header.clone().into()]);
+		sync.on_headers(2, vec![block.block_header.clone().into()]);
 		executor.take_tasks();
 		sync.on_block(2, block.clone().into());
 
@@ -1573,7 +1576,7 @@ pub mod tests {
 
 		let b1 = test_data::block_h1();
 		let b2 = test_data::block_h2();
-		sync.on_headers(1, types::Headers::with_headers(vec![b1.block_header.clone(), b2.block_header.clone()]));
+		sync.on_headers(1, vec![b1.block_header.clone().into(), b2.block_header.clone().into()]);
 
 		let tasks = executor.take_tasks();
 		assert_eq!(tasks.len(), 2);
@@ -1615,7 +1618,7 @@ pub mod tests {
 
 		let b1 = test_data::block_h1();
 		let b2 = test_data::block_h2();
-		sync.on_headers(1, types::Headers::with_headers(vec![b1.block_header.clone(), b2.block_header.clone()]));
+		sync.on_headers(1, vec![b1.block_header.clone().into(), b2.block_header.clone().into()]);
 
 		let tasks = executor.take_tasks();
 		assert_eq!(tasks.len(), 2);
@@ -1656,7 +1659,7 @@ pub mod tests {
 		let (executor, core, sync) = create_sync(None, None);
 
 		let b169 = test_data::block_h169();
-		sync.on_headers(1, types::Headers::with_headers(vec![b169.block_header]));
+		sync.on_headers(1, vec![b169.block_header.into()]);
 
 		let tasks = executor.take_tasks();
 		assert_eq!(tasks, vec![]);
@@ -1676,8 +1679,12 @@ pub mod tests {
 		let fork1 = test_data::build_n_empty_blocks_from(2, 100, &genesis_header);
 		let fork2 = test_data::build_n_empty_blocks_from(3, 200, &genesis_header);
 
-		sync.on_headers(1, types::Headers::with_headers(vec![fork1[0].block_header.clone(), fork1[1].block_header.clone()]));
-		sync.on_headers(2, types::Headers::with_headers(vec![fork2[0].block_header.clone(), fork2[1].block_header.clone(), fork2[2].block_header.clone()]));
+		sync.on_headers(1, vec![fork1[0].block_header.clone().into(), fork1[1].block_header.clone().into()]);
+		sync.on_headers(2, vec![
+			fork2[0].block_header.clone().into(),
+			fork2[1].block_header.clone().into(),
+			fork2[2].block_header.clone().into(),
+		]);
 		let tasks = { executor.take_tasks() };
 		assert_eq!(tasks, vec![request_block_headers_genesis_and(1, vec![fork1[1].hash(), fork1[0].hash()]),
 			request_blocks(1, vec![fork1[0].hash(), fork1[1].hash()]),
@@ -1732,8 +1739,17 @@ pub mod tests {
 		let fork1 = test_data::build_n_empty_blocks_from(2, 100, &common_block.block_header);
 		let fork2 = test_data::build_n_empty_blocks_from(3, 200, &common_block.block_header);
 
-		sync.on_headers(1, types::Headers::with_headers(vec![common_block.block_header.clone(), fork1[0].block_header.clone(), fork1[1].block_header.clone()]));
-		sync.on_headers(2, types::Headers::with_headers(vec![common_block.block_header.clone(), fork2[0].block_header.clone(), fork2[1].block_header.clone(), fork2[2].block_header.clone()]));
+		sync.on_headers(1, vec![
+			common_block.block_header.clone().into(),
+			fork1[0].block_header.clone().into(),
+			fork1[1].block_header.clone().into(),
+		]);
+		sync.on_headers(2, vec![
+			common_block.block_header.clone().into(),
+			fork2[0].block_header.clone().into(),
+			fork2[1].block_header.clone().into(),
+			fork2[2].block_header.clone().into(),
+		]);
 
 		let tasks = { executor.take_tasks() };
 		assert_eq!(tasks, vec![request_block_headers_genesis_and(1, vec![fork1[1].hash(), fork1[0].hash(), common_block.hash()]),
@@ -1810,7 +1826,7 @@ pub mod tests {
 
 		{
 			// receive inventory from new peer#1
-			sync.on_headers(1, types::Headers::with_headers(vec![block1.block_header.clone()]));
+			sync.on_headers(1, vec![block1.block_header.clone().into()]);
 			// synchronization has started && new blocks have been requested
 			let tasks = executor.take_tasks();
 			assert_eq!(tasks, vec![
@@ -1821,7 +1837,7 @@ pub mod tests {
 
 		{
 			// receive inventory from new peer#2
-			sync.on_headers(2, types::Headers::with_headers(vec![block1.block_header.clone(), block2.block_header.clone()]));
+			sync.on_headers(2, vec![block1.block_header.clone().into(), block2.block_header.clone().into()]);
 			// synchronization has started && new blocks have been requested
 			let tasks = executor.take_tasks();
 			assert_eq!(tasks, vec![
@@ -1860,7 +1876,7 @@ pub mod tests {
 
 		let b1 = test_data::block_h1();
 		let b2 = test_data::block_h2();
-		sync.on_headers(1, types::Headers::with_headers(vec![b1.block_header.clone(), b2.block_header.clone()]));
+		sync.on_headers(1, vec![b1.block_header.clone().into(), b2.block_header.clone().into()]);
 
 		let tasks = executor.take_tasks();
 		assert_eq!(tasks, vec![request_block_headers_genesis_and(1, vec![b2.hash().clone(), b1.hash().clone()]), request_blocks(1, vec![b1.hash(), b2.hash()])]);
@@ -1885,7 +1901,7 @@ pub mod tests {
 
 		let b1 = test_data::block_h1();
 		let b2 = test_data::block_h2();
-		sync.on_headers(1, types::Headers::with_headers(vec![b1.block_header.clone(), b2.block_header.clone()]));
+		sync.on_headers(1, vec![b1.block_header.clone().into(), b2.block_header.clone().into()]);
 
 		let tasks = executor.take_tasks();
 		assert_eq!(tasks, vec![request_block_headers_genesis_and(1, vec![b2.hash().clone(), b1.hash().clone()]), request_blocks(1, vec![b1.hash(), b2.hash()])]);
@@ -1916,7 +1932,7 @@ pub mod tests {
 		}
 
 		let b1 = test_data::block_h1();
-		sync.on_headers(1, types::Headers::with_headers(vec![b1.block_header.clone()]));
+		sync.on_headers(1, vec![b1.block_header.clone().into()]);
 
 		assert!(core.lock().information().state.is_nearly_saturated());
 		{ executor.take_tasks(); } // forget tasks
@@ -1965,7 +1981,7 @@ pub mod tests {
 
 		let b1 = test_data::block_h1();
 		let b2 = test_data::block_h2();
-		sync.on_headers(1, types::Headers::with_headers(vec![b1.block_header.clone(), b2.block_header.clone()]));
+		sync.on_headers(1, vec![b1.block_header.into(), b2.block_header.into()]);
 
 		assert!(core.lock().information().state.is_synchronizing());
 
@@ -1984,7 +2000,7 @@ pub mod tests {
 		assert_eq!(core.lock().information().chain.transactions.transactions_count, 1);
 
 		let b2 = test_data::block_h2();
-		sync.on_headers(1, types::Headers::with_headers(vec![b2.block_header.clone()]));
+		sync.on_headers(1, vec![b2.block_header.into()]);
 
 		assert!(core.lock().information().state.is_nearly_saturated());
 
@@ -2053,8 +2069,16 @@ pub mod tests {
 
 		let (_, _, sync) = create_sync(None, Some(dummy_verifier));
 
-		sync.on_headers(1, types::Headers::with_headers(vec![b10.block_header.clone(), b11.block_header.clone(), b12.block_header.clone()]));
-		sync.on_headers(2, types::Headers::with_headers(vec![b10.block_header.clone(), b21.block_header.clone(), b22.block_header.clone()]));
+		sync.on_headers(1, vec![
+			b10.block_header.clone().into(),
+			b11.block_header.clone().into(),
+			b12.block_header.clone().into(),
+		]);
+		sync.on_headers(2, vec![
+			b10.block_header.clone().into(),
+			b21.block_header.clone().into(),
+			b22.block_header.clone().into(),
+		]);
 
 		sync.on_block(1, b10.clone().into());
 		sync.on_block(1, b11.into());
@@ -2063,8 +2087,12 @@ pub mod tests {
 		sync.on_block(2, b21.clone().into());
 
 		// should not panic here
-		sync.on_headers(2, types::Headers::with_headers(vec![b10.block_header.clone(), b21.block_header.clone(),
-			b22.block_header.clone(), b23.block_header.clone()]));
+		sync.on_headers(2, vec![
+			b10.block_header.into(),
+			b21.block_header.into(),
+			b22.block_header.into(),
+			b23.block_header.into(),
+		]);
 	}
 
 	#[test]
@@ -2076,7 +2104,7 @@ pub mod tests {
 		let b2 = test_data::block_builder().header().parent(b1.hash()).build().build();
 		let b3 = test_data::block_builder().header().parent(b2.hash()).build().build();
 
-		sync.on_headers(1, types::Headers::with_headers(vec![b0.block_header.clone(), b1.block_header.clone()]));
+		sync.on_headers(1, vec![b0.block_header.clone().into(), b1.block_header.clone().into()]);
 		sync.on_block(1, b0.clone().into());
 		sync.on_block(1, b1.clone().into());
 
@@ -2103,7 +2131,7 @@ pub mod tests {
 			]);
 		}
 
-		sync.on_headers(1, types::Headers::with_headers(vec![b3.block_header.clone()]));
+		sync.on_headers(1, vec![b3.block_header.clone().into()]);
 		sync.on_block(1, b3.clone().into());
 
 		// we were in nearly saturated state => block is relayed
@@ -2172,7 +2200,7 @@ pub mod tests {
 		core.lock().peers.insert(0, Services::default(), DummyOutboundSyncConnection::new());
 		assert!(core.lock().peers.enumerate().contains(&0));
 
-		sync.on_headers(0, types::Headers::with_headers(vec![b0.block_header.clone(), b1.block_header.clone(), b2.block_header.clone()]));
+		sync.on_headers(0, vec![b0.block_header.into(), b1.block_header.into(), b2.block_header.into()]);
 
 		assert!(!core.lock().peers.enumerate().contains(&0));
 	}
@@ -2194,7 +2222,7 @@ pub mod tests {
 		core.lock().peers.insert(0, Services::default(), DummyOutboundSyncConnection::new());
 		assert!(core.lock().peers.enumerate().contains(&0));
 
-		sync.on_headers(0, types::Headers::with_headers(vec![b0.block_header.clone(), b1.block_header.clone(), b2.block_header.clone()]));
+		sync.on_headers(0, vec![b0.block_header.into(), b1.block_header.into(), b2.block_header.into()]);
 
 		assert!(!core.lock().peers.enumerate().contains(&0));
 	}
@@ -2248,9 +2276,9 @@ pub mod tests {
 		let (executor, core, sync) = create_sync(None, None);
 
 		// when peer1 announces 'false' b0
-		sync.on_headers(1, types::Headers::with_headers(vec![b0.block_header.clone()]));
+		sync.on_headers(1, vec![b0.block_header.clone().into()]);
 		// and peer2 announces 'true' b1
-		sync.on_headers(2, types::Headers::with_headers(vec![b1.block_header.clone(), b2.block_header.clone()]));
+		sync.on_headers(2, vec![b1.block_header.clone().into(), b2.block_header.clone().into()]);
 
 		// check that all blocks are requested
 		assert_eq!(core.lock().information().chain.requested, 3);
@@ -2407,12 +2435,12 @@ pub mod tests {
 		assert_eq!(data.lock().best_blocks.len(), 0);
 
 		// supply with new block header => is_synchronizing is still false
-		sync.on_headers(0, types::Headers::with_headers(vec![test_data::block_h1().block_header]));
+		sync.on_headers(0, vec![test_data::block_h1().block_header.into()]);
 		assert_eq!(data.lock().is_synchronizing, false);
 		assert_eq!(data.lock().best_blocks.len(), 0);
 
 		// supply with 2 new blocks headers => is_synchronizing is true
-		sync.on_headers(0, types::Headers::with_headers(vec![test_data::block_h2().block_header, test_data::block_h3().block_header]));
+		sync.on_headers(0, vec![test_data::block_h2().block_header.into(), test_data::block_h3().block_header.into()]);
 		assert_eq!(data.lock().is_synchronizing, true);
 		assert_eq!(data.lock().best_blocks.len(), 0);
 

--- a/sync/src/synchronization_client_core.rs
+++ b/sync/src/synchronization_client_core.rs
@@ -72,7 +72,7 @@ pub trait ClientCore {
 	fn on_connect(&mut self, peer_index: PeerIndex);
 	fn on_disconnect(&mut self, peer_index: PeerIndex);
 	fn on_inventory(&self, peer_index: PeerIndex, message: types::Inv);
-	fn on_headers(&mut self, peer_index: PeerIndex, message: types::Headers) -> Option<Vec<IndexedBlockHeader>>;
+	fn on_headers(&mut self, peer_index: PeerIndex, headers: Vec<IndexedBlockHeader>) -> Option<Vec<IndexedBlockHeader>>;
 	fn on_block(&mut self, peer_index: PeerIndex, block: IndexedBlock) -> Option<VecDeque<PartiallyVerifiedBlock>>;
 	fn on_transaction(&mut self, peer_index: PeerIndex, transaction: IndexedTransaction) -> Option<VecDeque<IndexedTransaction>>;
 	fn on_notfound(&mut self, peer_index: PeerIndex, message: types::NotFound);
@@ -254,11 +254,8 @@ impl<T> ClientCore for SynchronizationClientCore<T> where T: TaskExecutor {
 	}
 
 	/// Try to queue synchronization of unknown blocks when blocks headers are received.
-	fn on_headers(&mut self, peer_index: PeerIndex, message: types::Headers) -> Option<Vec<IndexedBlockHeader>> {
-		assert!(!message.headers.is_empty(), "This must be checked in incoming connection");
-
-		// transform to indexed headers
-		let headers: Vec<_> = message.headers.into_iter().map(IndexedBlockHeader::from_raw).collect();
+	fn on_headers(&mut self, peer_index: PeerIndex, headers: Vec<IndexedBlockHeader>) -> Option<Vec<IndexedBlockHeader>> {
+		assert!(!	headers.is_empty(), "This must be checked in incoming connection");
 
 		// update peers to select next tasks
 		self.peers_tasks.on_headers_received(peer_index);


### PR DESCRIPTION
Before this PR incoming headers were hashed in `SynchronizationClientCore`, under synchronization lock. Now they're hashed before the lock is acqired