### PR TITLE
Ignore zero-filled gaps in blk files

### DIFF
--- a/serialization/src/reader.rs
+++ b/serialization/src/reader.rs
@@ -90,6 +90,24 @@ impl<R> Reader<R> where R: io::Read {
 		T::deserialize(&mut reader)
 	}
 
+	pub fn skip_while(&mut self, predicate: &Fn(u8) -> bool) -> Result<(), Error> {
+		let mut next_buffer = [0u8];
+		loop {
+			let next = match self.peeked.take() {
+				Some(peeked) => peeked,
+				None => match self.buffer.read(&mut next_buffer)? {
+					0 => return Ok(()),
+					_ => next_buffer[0],
+				},
+			};
+
+			if !predicate(next) {
+				self.peeked = Some(next);
+				return Ok(());
+			}
+		}
+	}
+
 	pub fn read_slice(&mut self, bytes: &mut [u8]) -> Result<(), Error> {
 		io::Read::read_exact(self, bytes).map_err(|_| Error::UnexpectedEnd)
 	}


### PR DESCRIPTION
closes #82 

Looks like the blk-files structure slightly differs from what we were assuming earlier. [Here](https://www.dropbox.com/s/q3u8v3ext2lzbcj/blk00066.dat?dl=0) you can find file having extra 7 zero bytes between blocks #248859 and #248860. Parsing blocks index file (the file that has pointers to blocks positions in blk files) has never been in our plans. So the only solution I could think of is to skip inter-block bytes until first non-zero byte is met. Block is always prefixed by magic and, iirc, magic is designed not to have zero bytes in it (on all BTC-like chains) => that should work (only if gaps are zero-filled, though).