### PR TITLE
Workspace dependabot dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,23 @@ name = "pzec"
 members = [
     "bencher",
     "chain",
+	"db",
+	"import",
+	"keys",
+	"logs",
+	"message",
+	"miner",
+	"network",
+	"p2p",
+	"primitives",
+	"rpc",
+	"script",
+	"serialization",
+	"serialization_derive",
+	"storage",
+	"sync",
+	"test-data",
+	"verification",
 ]
 
 [patch.crates-io]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,26 +6,26 @@ authors = ["Parity Technologies <admin@parity.io>"]
 description = "Parity bitcoin client."
 
 [dependencies]
-log = "0.4"
-env_logger = "0.5"
 app_dirs = { git = "https://github.com/paritytech/app-dirs-rs" }
-libc = "0.2"
-clap = { version = "2", features = ["yaml"] }
 chain = { path = "chain" }
+clap = { version = "2", features = ["yaml"] }
+db = { path = "db" }
+env_logger = "0.5"
+import = { path = "import" }
 keys = { path = "keys" }
+libc = "0.2"
+log = "0.4"
+logs = { path = "logs" }
 message = { path = "message" }
 network = { path = "network" }
 miner = { path = "miner" }
 p2p = { path = "p2p" }
+primitives = { path = "primitives" }
+rpc = { path = "rpc" }
 script = { path = "script" }
 storage = { path = "storage" }
-db = { path = "db" }
-verification = { path = "verification" }
 sync = { path = "sync" }
-import = { path = "import" }
-logs = { path = "logs" }
-rpc = { path = "rpc" }
-primitives = { path = "primitives" }
+verification = { path = "verification" }
 
 [profile.dev]
 debug = true
@@ -43,7 +43,10 @@ path = "pzec/main.rs"
 name = "pzec"
 
 [workspace]
-members = ["bencher"]
+members = [
+    "bencher",
+    "chain",
+]
 
 [patch.crates-io]
 heapsize = { git = "https://github.com/cheme/heapsize.git", branch = "ec-macfix" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,9 @@ name = "pzec"
 
 [workspace]
 members = [
-    "bencher",
-    "chain",
+	"bencher",
+	"./crypto",
+	"chain",
 	"db",
 	"import",
 	"keys",


### PR DESCRIPTION
The primary reason for this is so that Dependabot will auto-detect them and
watch their dependencies for upgrades and known security vulnerabilities. I've
included 'test-data' here mostly because we want all dependencies inter-consistent
when possible even for test data/code, even if that means 'test-data' gets built
during 'cargo build --release'.